### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/keep-alive.yml
+++ b/.github/workflows/keep-alive.yml
@@ -6,6 +6,8 @@ on:
     - cron: '*/30 * * * *'
   workflow_dispatch: # Permet de déclencher manuellement
 
+permissions: {}
+
 jobs:
   keep-alive:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/ValMtp3/Bento-Grid-Portfolio/security/code-scanning/1](https://github.com/ValMtp3/Bento-Grid-Portfolio/security/code-scanning/1)

Add an explicit `permissions` block at the workflow root so all jobs inherit least-privilege defaults.  
For this workflow, the safest minimal fix without changing behavior is:

- `permissions: {}` (equivalent to no token permissions)

This workflow only does outbound HTTP ping and logging, so it does not require `GITHUB_TOKEN` access.  
Edit `.github/workflows/keep-alive.yml` near the top-level keys: insert `permissions: {}` between `on:` and `jobs:` (or anywhere at root level). No imports, methods, or additional definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
